### PR TITLE
feat(helm): expose release.Hooks in CEL expressions

### DIFF
--- a/pkg/provider/helm/README.md
+++ b/pkg/provider/helm/README.md
@@ -41,6 +41,18 @@ The following variables are available in CEL expressions:
 - `release.Labels` - Release labels (map)
 - `release.Config` - User-provided value overrides (map)
 - `release.ApplyMethod` - Apply strategy used for the release: `"csa"` (client-side apply) or `"ssa"` (server-side apply). Defaults to `"csa"` for pre-v4 releases.
+- `release.Hooks` - List of lifecycle hooks (list of maps). Each hook has:
+  - `Name` - Hook resource name (string)
+  - `Kind` - Kubernetes kind, e.g. `"Job"` (string)
+  - `Path` - Chart-relative template path (string)
+  - `Events` - When the hook fires (list of strings: `"pre-install"`, `"post-install"`, `"pre-upgrade"`, `"post-upgrade"`, `"pre-delete"`, `"post-delete"`, `"pre-rollback"`, `"post-rollback"`, `"test"`)
+  - `Weight` - Execution order among same-event hooks (int)
+  - `DeletePolicies` - Cleanup policies (list of strings: `"hook-succeeded"`, `"hook-failed"`, `"before-hook-creation"`)
+  - `OutputLogPolicies` - Log capture policies (list of strings: `"hook-succeeded"`, `"hook-failed"`)
+  - `LastRun` - Last execution result (map):
+    - `StartedAt` - Execution start timestamp
+    - `CompletedAt` - Execution completion timestamp
+    - `Phase` - Result: `""` (never run), `"Unknown"`, `"Running"`, `"Succeeded"`, `"Failed"`
 
 ### Chart Properties
 
@@ -97,3 +109,21 @@ This example validates that:
 - The chart is not deprecated
 - Required labels are present
 - The replica count meets production requirements
+
+### Hook Validation
+
+```yaml
+components:
+  my-app:
+    type: helm
+    spec:
+      release: my-app
+      namespace: production
+    checks:
+      - check: '!release.Hooks.exists(h, h.LastRun.Phase == "Failed")'
+        message: "One or more hooks have failed"
+      - check: 'release.Hooks.filter(h, h.Events.exists(e, e == "test")).size() > 0'
+        message: "Release must have test hooks"
+      - check: 'release.ApplyMethod == "ssa"'
+        message: "Release must use server-side apply"
+```

--- a/pkg/provider/helm/helm.go
+++ b/pkg/provider/helm/helm.go
@@ -167,6 +167,35 @@ func unmarshalManifest(manifestStr string) []map[string]any {
 	return result
 }
 
+func toStrings[S ~string](ss []S) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = string(s)
+	}
+	return out
+}
+
+func hooksToMaps(hooks []*release.Hook) []map[string]any {
+	result := make([]map[string]any, 0, len(hooks))
+	for _, h := range hooks {
+		result = append(result, map[string]any{
+			"Name":              h.Name,
+			"Kind":              h.Kind,
+			"Path":              h.Path,
+			"Events":            toStrings(h.Events),
+			"Weight":            h.Weight,
+			"DeletePolicies":    toStrings(h.DeletePolicies),
+			"OutputLogPolicies": toStrings(h.OutputLogPolicies),
+			"LastRun": map[string]any{
+				"StartedAt":   h.LastRun.StartedAt,
+				"CompletedAt": h.LastRun.CompletedAt,
+				"Phase":       string(h.LastRun.Phase),
+			},
+		})
+	}
+	return result
+}
+
 func releaseToMaps(rel *release.Release) (releaseMap map[string]any, chartMap map[string]any) {
 	releaseMap = map[string]any{
 		"Name":        rel.Name,
@@ -176,6 +205,7 @@ func releaseToMaps(rel *release.Release) (releaseMap map[string]any, chartMap ma
 		"Manifest":    unmarshalManifest(rel.Manifest),
 		"Labels":      rel.Labels,
 		"ApplyMethod": cmp.Or(rel.ApplyMethod, string(release.ApplyMethodClientSideApply)),
+		"Hooks":       hooksToMaps(rel.Hooks),
 	}
 
 	// Add Info fields directly to release (flattened for cleaner access)

--- a/pkg/provider/helm/helm_test.go
+++ b/pkg/provider/helm/helm_test.go
@@ -93,6 +93,21 @@ func testRelease(name string, status common.Status) *release.Release {
 			"team": "platform",
 			"env":  "prod",
 		},
+		Hooks: []*release.Hook{
+			{
+				Name:   "my-release-pre-install",
+				Kind:   "Job",
+				Path:   "templates/pre-install.yaml",
+				Events: []release.HookEvent{release.HookPreInstall},
+				LastRun: release.HookExecution{
+					StartedAt:   time.Now().Add(-1 * time.Minute),
+					CompletedAt: time.Now().Add(-30 * time.Second),
+					Phase:       release.HookPhaseSucceeded,
+				},
+				Weight:         0,
+				DeletePolicies: []release.HookDeletePolicy{release.HookSucceeded},
+			},
+		},
 	}
 }
 
@@ -510,6 +525,92 @@ func TestCEL_ApplyMethod(t *testing.T) {
 			assert.Equal(t, tt.expectedStatus, result.Status)
 		})
 	}
+}
+
+func TestCEL_Hooks(t *testing.T) {
+	tests := []struct {
+		name  string
+		check string
+	}{
+		{"count", `size(release.Hooks) == 1`},
+		{"name", `release.Hooks[0].Name == "my-release-pre-install"`},
+		{"kind", `release.Hooks[0].Kind == "Job"`},
+		{"path", `release.Hooks[0].Path == "templates/pre-install.yaml"`},
+		{"event_exists", `release.Hooks[0].Events.exists(e, e == "pre-install")`},
+		{"phase_succeeded", `release.Hooks[0].LastRun.Phase == "Succeeded"`},
+		{"all_succeeded", `release.Hooks.all(h, h.LastRun.Phase == "" || h.LastRun.Phase == "Succeeded")`},
+		{"no_failed", `!release.Hooks.exists(h, h.LastRun.Phase == "Failed")`},
+		{"delete_policy", `release.Hooks[0].DeletePolicies.exists(p, p == "hook-succeeded")`},
+		{"weight", `release.Hooks[0].Weight == 0`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupMockFactory(t, testRelease("my-release", common.StatusDeployed), nil)
+
+			instance := &helm.Component{
+				Release:   "my-release",
+				Namespace: "default",
+			}
+			instance.SetName("test-helm")
+			require.NoError(t, instance.Setup())
+			require.NoError(t, instance.SetChecks([]checks.Expression{
+				{Expression: tt.check},
+			}))
+
+			result := instance.GetHealth(t.Context())
+			assert.Equal(t, ph.Status_HEALTHY, result.Status)
+		})
+	}
+}
+
+func TestCEL_HooksEmpty(t *testing.T) {
+	rel := testRelease("my-release", common.StatusDeployed)
+	rel.Hooks = nil
+	setupMockFactory(t, rel, nil)
+
+	instance := &helm.Component{
+		Release:   "my-release",
+		Namespace: "default",
+	}
+	instance.SetName("test-helm")
+	require.NoError(t, instance.Setup())
+	require.NoError(t, instance.SetChecks([]checks.Expression{
+		{Expression: "size(release.Hooks) == 0"},
+	}))
+
+	result := instance.GetHealth(t.Context())
+	assert.Equal(t, ph.Status_HEALTHY, result.Status)
+}
+
+func TestCEL_HooksFailed(t *testing.T) {
+	rel := testRelease("my-release", common.StatusDeployed)
+	rel.Hooks = []*release.Hook{
+		{
+			Name:   "failing-hook",
+			Kind:   "Job",
+			Events: []release.HookEvent{release.HookPreUpgrade},
+			LastRun: release.HookExecution{
+				Phase: release.HookPhaseFailed,
+			},
+		},
+	}
+	setupMockFactory(t, rel, nil)
+
+	instance := &helm.Component{
+		Release:   "my-release",
+		Namespace: "default",
+	}
+	instance.SetName("test-helm")
+	require.NoError(t, instance.Setup())
+	require.NoError(t, instance.SetChecks([]checks.Expression{
+		{Expression: `!release.Hooks.exists(h, h.LastRun.Phase == "Failed")`, Message: "hook failed"},
+	}))
+
+	result := instance.GetHealth(t.Context())
+	assert.Equal(t, ph.Status_UNHEALTHY, result.Status)
+	require.NotEmpty(t, result.Messages)
+	assert.Contains(t, result.Messages[0], "hook failed")
 }
 
 // slowStatusRunner is a mock that delays before returning


### PR DESCRIPTION
Add support for accessing Helm release hooks and their execution status in CEL expressions for validation and checks. Update docs and add tests for hook-related CEL usage.