### PR TITLE
refactor(helm): improve image reference assembly logic

### DIFF
--- a/deploy/charts/platform-health/templates/_helpers.tpl
+++ b/deploy/charts/platform-health/templates/_helpers.tpl
@@ -65,3 +65,55 @@ Name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{-   end }}
 {{- end }}
+
+{{/*
+Fully-assembled container image reference.
+
+Resolution rules:
+  - Repository path:
+      image.repository (if set)   -> used verbatim
+      else                        -> image.registry + "/" + image.name
+  - Tag:
+      image.tag non-empty         -> used verbatim
+      image.tag == "" (explicit)  -> omitted if image.digest is set, else falls back
+      image.tag unset/nil         -> Chart.AppVersion, else "latest"
+  - Digest (image.digest):
+      when set                    -> appended as "@<digest>"
+      combined with a tag renders as "<repo>:<tag>@<digest>" (OCI-valid).
+  - Values are concatenated raw and the fully-assembled reference is passed
+    through `tpl` once at the end, so individual fields (or the whole thing)
+    may contain template expressions (e.g.
+    "{{ `{{ .Values.global.oci_registry }}` }}").
+*/}}
+{{- define "platform-health.image" -}}
+{{- $img := .Values.image -}}
+{{- $repo := "" -}}
+{{- if $img.repository -}}
+{{-   $repo = $img.repository -}}
+{{- else -}}
+{{-   $registry := "" -}}
+{{-   if $img.registry -}}{{- $registry = $img.registry | trimSuffix "/" -}}{{- end -}}
+{{-   $name := "" -}}
+{{-   if $img.name -}}{{- $name = $img.name | trimPrefix "/" -}}{{- end -}}
+{{-   if $registry -}}
+{{-     $repo = printf "%s/%s" $registry $name -}}
+{{-   else -}}
+{{-     $repo = $name -}}
+{{-   end -}}
+{{- end -}}
+{{- $digest := default "" $img.digest -}}
+{{- $tag := "" -}}
+{{- if $img.tag -}}
+{{-   $tag = $img.tag -}}
+{{- else if kindIs "string" $img.tag -}}
+{{-   if not $digest -}}
+{{-     $tag = default "latest" .Chart.AppVersion -}}
+{{-   end -}}
+{{- else -}}
+{{-   $tag = default "latest" .Chart.AppVersion -}}
+{{- end -}}
+{{- $ref := $repo -}}
+{{- if $tag -}}{{- $ref = printf "%s:%s" $ref $tag -}}{{- end -}}
+{{- if $digest -}}{{- $ref = printf "%s@%s" $ref $digest -}}{{- end -}}
+{{- tpl $ref . -}}
+{{- end }}

--- a/deploy/charts/platform-health/templates/deployment.yaml
+++ b/deploy/charts/platform-health/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "chart.fullname" . }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion | default .Values.image.tag }}"
+          image: {{ include "platform-health.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: &port {{ .Values.containerPort }}

--- a/deploy/charts/platform-health/values.yaml
+++ b/deploy/charts/platform-health/values.yaml
@@ -15,9 +15,32 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Application container :: custom configuration
+#
+# The image reference is assembled as:
+#   <registry>/<name>[:<tag>][@<digest>]
+# or, if `repository` is set, as:
+#   <repository>[:<tag>][@<digest>]
+#
+# All string fields below are passed through `tpl`, so values may themselves
+# contain template expressions — for example:
+#   image:
+#     registry: "{{ .Values.global.oci_registry }}"
 image:
-  repository: ghcr.io/isometry/platform-health
+  # Registry host (e.g. ghcr.io, quay.io, a pull-through mirror).
+  registry: ghcr.io
+  # Image path within the registry.
+  name: isometry/platform-health
+  # Full registry+name override. When set, `registry` and `name` are ignored.
+  # Useful for air-gapped deployments that repaste the entire path.
+  repository: ~
+  # Tag. When unset, defaults to Chart.AppVersion, falling back to "latest".
+  # Digests belong in `digest`, not here.
   tag: ~
+  # Content-addressed digest (e.g. "sha256:..."). When set, is appended as
+  # "@<digest>". If `tag` is also set, renders as "<name>:<tag>@<digest>"
+  # (OCI-valid: runtime pulls by digest, tag stays as a human-readable hint).
+  # Set `tag: ""` alongside `digest` to omit the tag segment entirely.
+  digest: ~
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
- add helper template to assemble image reference from registry, name, tag, and digest fields.
- update deployment to use the new helper.
- expand image field documentation in values.yaml.